### PR TITLE
Simplify assign_coords

### DIFF
--- a/xarray_jax/__init__.py
+++ b/xarray_jax/__init__.py
@@ -270,11 +270,7 @@ def assign_coords(
     The Dataset or DataArray with coordinates assigned, similarly to
     Dataset.assign_coords / DataArray.assign_coords.
   """
-  coords = {} if coords is None else dict(coords)  # Copy before mutating.
   jax_coords = {} if jax_coords is None else dict(jax_coords)
-
-  existing_jax_coords = get_jax_coords(x)
-  jax_coords = existing_jax_coords | jax_coords
 
   # Assign static coordinates directly
   if coords: x = x.assign_coords(coords)


### PR DESCRIPTION
## Description
Simplified `assign_coords()`, removing the workarounds for [Xarray issue #7885](https://github.com/pydata/xarray/issues/7885) and automatic indexing on jax_coords.

## Changes
- Removed the `drop_vars()` logic, directly assigning static coordinates
- Removed the renaming logic for `jax_coords`, directly using the `xarray.Coordinates()` constructor with `indexes={}` to [bypass automatic indexing](https://docs.xarray.dev/en/latest/generated/xarray.Coordinates.html#:~:text=indexes%20(dict%2Dlike%2C%20optional)%20%E2%80%93%20Mapping%20where%20keys%20are%20coordinate%20names%20and%20values%20are%20Index%20objects.%20If%20None%20(default)%2C%20pandas%20indexes%20will%20be%20created%20for%20each%20dimension%20coordinate.%20Passing%20an%20empty%20dictionary%20will%20skip%20this%20default%20behavior.)


Closes #1