### PR TITLE
Add vmap with corresponding tests

### DIFF
--- a/xarray_jax/__init__.py
+++ b/xarray_jax/__init__.py
@@ -93,6 +93,7 @@ from xarray_jax.core import (
     Variable,
 )
 from xarray_jax.jax_transforms import (
+    vmap,
     pmap,
     scan,
     tree_map_variables,
@@ -120,6 +121,7 @@ __all__ = (
     'get_jax_coords',
     'Variable',
     # jax_transforms
+    'vmap',
     'pmap',
     'scan',
     'tree_map_variables',

--- a/xarray_jax/jax_transforms.py
+++ b/xarray_jax/jax_transforms.py
@@ -19,6 +19,75 @@ import jax
 import xarray
 from xarray_jax import pytree
 
+def vmap(fn: Callable[..., Any],
+         dim: str,
+         axis_name: Optional[str] = None,
+         axis_size: int | None = None,
+         spmd_axis_name: Any | None = None) -> Callable[..., Any]:
+  """Wraps a subset of jax.vmap functionality to handle xarray input/output.
+
+  Constraints:
+    * Any Dataset or DataArray passed to the function must have `dim` as the
+      first dimension. This will be checked. You can ensure this if necessary
+      by calling `.transpose(dim, ...)` beforehand.
+    * All args and return values will be mapped over the first dimension,
+      it will use in_axes=0, out_axes=0. No broadcasting is supported.
+
+  Args:
+    fn: Function to be vmap'd which takes and returns trees which may contain
+      xarray Dataset/DataArray. Any Dataset/DataArrays passed as input must use
+      `dim` as the first dimension on all arrays.
+    dim: The xarray dimension name corresponding to the first dimension that is
+      vmapped over (vmap is called with in_axes=0, out_axes=0).
+    axis_name:
+    axis_size:
+    spmd_axis_name:
+      See jax.vmap.
+
+  Returns:
+    A vmap'd version of `fn`, which takes and returns Dataset/DataArray with an
+    extra leading dimension `dim` relative to what the original `fn` sees.
+  """
+  input_treedef = None
+  output_treedef = None
+
+  def fn_passed_to_vmap(*flat_args):
+    assert input_treedef is not None
+    # Inside the vmap the original first dimension will no longer be present:
+    def check_and_remove_leading_dim(dims):
+      try:
+        index = dims.index(dim)
+      except ValueError:
+        index = None
+      if index != 0:
+        raise ValueError(f'Expected dim {dim} at index 0, found at {index}.')
+      return dims[1:]
+    with pytree.dims_change_on_unflatten(check_and_remove_leading_dim):
+      args = jax.tree_util.tree_unflatten(input_treedef, flat_args)
+    result = fn(*args)
+    nonlocal output_treedef
+    flat_result, output_treedef = jax.tree_util.tree_flatten(result)
+    return flat_result
+
+  vmapped_fn = jax.vmap(
+      fn_passed_to_vmap,
+      in_axes=0,
+      out_axes=0,
+      axis_name=axis_name or dim,
+      axis_size=axis_size,
+      spmd_axis_name=spmd_axis_name)
+
+  def result_fn(*args):
+    nonlocal input_treedef
+    flat_args, input_treedef = jax.tree_util.tree_flatten(args)
+    flat_result = vmapped_fn(*flat_args)
+    assert output_treedef is not None
+    # After the vmap an extra leading axis will be present, we need to add an
+    # xarray dimension for this when unflattening the result:
+    with pytree.dims_change_on_unflatten(lambda dims: (dim,) + dims):
+      return jax.tree_util.tree_unflatten(output_treedef, flat_result)
+
+  return result_fn
 
 def pmap(fn: Callable[..., Any],
          dim: str,


### PR DESCRIPTION
## Description

This PR introduces `xarray_jax.vmap`, a wrapper around `jax.vmap` that supports Xarray data structures by operating on named dimensions.

## Background

This PR adds a wrapper that allows users to specify the mapped dimension by name (e.g., `'batch'`). The implementation follows the logic and style established in the `xarray_jax.pmap` wrapper, as the `jax.vmap` API is based on integer-indexed axes and does not natively work with named dimensions. 

The wrapper forwards `axis_name` and `spmd_axis_name` to`jax.vmap`, providing support for features like parallel collectives (`psum`) and SPMD sharding.

## Changes

- **Added `xarray_jax.vmap` wrapper** in `jax_transforms.py`:
    - Provides a dimension-aware interface to `jax.vmap`
    - Accepts a `dim` string to specify the dimension to map over
    - Forwards `axis_name`, `axis_size`, and `spmd_axis_name` arguments to `jax.vmap`
    - Reuses the established PyTree-handling logic from the `pmap` wrapper
- **Added tests** for `vmap` in `jax_transforms_test.py`:
    - Follows the structure of the `pmap` tests for consistency
    - `test_vmap`: Verifies basic functionality with `xarray_jax.Dataset`
    - `test_vmap_with_jax_coords`: Ensures dynamic `jax_coords` are handled correctly
    - `test_vmap_with_tree_mix_of_xarray_and_jax_array`: Confirms it works on mixed PyTrees containing both Xarray objects and plain JAX arrays
    - `test_vmap_complains_when_dim_not_first`: Checks for correct error handling
    - `test_vmap_axis_name_psum_broadcast`: Validates support for collectives
    - `test_vmap_spmd_axis_name_noop`: Confirms sharding arguments are correctly passed