### PR TITLE
build: Add pyproject.toml and standard package structure.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "xarray-jax"
+version = "0.0.1"
+description = "JAX-powered Xarray"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {text = "Apache-2.0"}
+authors = [
+  { name="DeepMind", email="noreply@google.com" },
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering",
+]
+dependencies = [
+    "jax",
+    "xarray",
+    "numpy",
+    "absl-py",
+    "chex",
+]
+
+[project.urls]
+"Homepage" = "https://github.com/google-deepmind/xarray_jax"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["xarray_jax*"]

--- a/xarray_jax/__init__.py
+++ b/xarray_jax/__init__.py
@@ -81,6 +81,8 @@ data_var instead of a coord. You won't be able to do indexing and slicing using
 the coordinate, but that wasn't going to work with a jax array anyway.
 """
 
+__version__ = "0.0.1"
+
 # pylint: disable=g-importing-member,g-multiple-import
 
 from xarray_jax.core import (


### PR DESCRIPTION
## Problem
Currently, the project lacks a standardized build configuration. This prevents users from installing it directly via `pip` or adding it as a dependency in other projects. Additionally, the package lacks a version identifier.

Fixes #10

## Solution
This PR adds a standard `pyproject.toml` and updates `__init__.py` to make the package installable and compliant with modern Python standards.

## Changes
- **Added `pyproject.toml`**:  Configures `setuptools` build backend.
- **Dependencies**:  Added `jax`, `xarray`, `numpy`, `absl-py`, and `chex` (required for tests).
- **Metadata**:  Added project description, classifiers (marked as Alpha), and homepage URL.
- **Versioning**:  Added `__version__ = "0.0.1"` to `src/xarray_jax/__init__.py`.

## Verification
Tested locally:
1. `pip install .` -> Successfully built and installed.
2. `python -c "import xarray_jax; print(xarray_jax.__version__)"` -> Prints `0.0.1`.